### PR TITLE
Change wording in the hosts section

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ VCCW includes customizable variables for setting the WordPress version (or beta 
 $ vagrant plugin install vagrant-hostsupdater
 ```
 
-Windows is not allow to change hosts-file. Please add 'wordpress.local 192.168.33.10' by yourself!
+Windows does not allow to change `hosts` files. Please add `wordpress.local 192.168.33.10` by yourself!
 
 ### 4. Please download <a class="latest-zipball">.zip</a> or <a class="latest-tarball">.tar.gz</a>.
 


### PR DESCRIPTION
Hi,
This is a quick PR to correct wording in the section that discuss how `hosts` file(s) can be changed. It also adds code markup to better express technical words from descriptive, plain English.
![20150404210749](https://cloud.githubusercontent.com/assets/14539/6994167/206f18e6-db0f-11e4-9361-a3f6a7019770.jpg)

Thanks!
