### PR TITLE
Changed the path in the example

### DIFF
--- a/index.md
+++ b/index.md
@@ -182,7 +182,7 @@ You can place shell scripts, so it will run at pre/post provisioning.
 
 set -ex
 
-/usr/local/bin/wp --path=/var/www/wordpress plugin install contact-form-7 --activate
+/usr/local/bin/wp --path=/var/www/html/ plugin install contact-form-7 --activate
 ```
 
 This example script will install and activate plugin "Contact Form 7" by WP-CLI.


### PR DESCRIPTION
The path to the WordPress installation is /var/www/html/ and not /var/www/wordpress/